### PR TITLE
taxi1: Fix the Speed Bonus calculation

### DIFF
--- a/main/taxi1.sc
+++ b/main/taxi1.sc
@@ -26,7 +26,7 @@ VAR_INT taxi_finish_time taxi_start_time total_taxi_time_taken
 VAR_INT score_for_this_fare	speedbonus in_a_row_cash in_a_row_number
 
 VAR_FLOAT taxi_destx1 taxi_desty1 taxi_destz1
-VAR_FLOAT taxi_blipx taxi_blipy taxi_blipz 
+//VAR_FLOAT taxi_blipx taxi_blipy taxi_blipz // SCFIX: III leftovers, now unused
 VAR_FLOAT taxi_ped_x taxi_ped_y taxi_ped_z
 VAR_FLOAT x_diff y_diff x_diff_sq y_diff_sq taxi_distance_sq taxi_distance 
 
@@ -707,8 +707,8 @@ IF IS_CAR_DEAD taxi_car1
 	GOTO mission_taxi1_failed
 ENDIF
 
-x_diff = taxi_ped_x - taxi_blipx
-y_diff = taxi_ped_y - taxi_blipy
+x_diff = taxi_ped_x - taxi_destx1 // SCFIX: Replaced 'taxi_blipx' with 'taxi_destx1'
+y_diff = taxi_ped_y - taxi_desty1 // SCFIX: Replaced 'taxi_blipy' with 'taxi_desty1'
 
 x_diff_sq = x_diff * x_diff
 y_diff_sq = y_diff * y_diff

--- a/readme.md
+++ b/readme.md
@@ -341,6 +341,7 @@ Misc:
 - Improved road traffic at Leaf Links bridge
 - Fixed player gaining wanted level when leaving the police department interior
 - Fixed taxi driver being able to become your passenger in a Taxi Driver side activity
+- Fixed the Speed Bonus calculation in a Taxi Driver side activity
 - Cutscene Kaufman Cab is now being deleted after the Kaufman Cabs purchase cutscene
 - Disabled "To enter Ocean View hotel..." message when on mission and after "An Old Friend"
 - Improved the position of a bonus Hunter at a south beach


### PR DESCRIPTION
`taxi_blipx` and `taxi_blipy` are GTA III leftovers that were never initialized, so the Speed Bonus effectively calculated distance from the map origin.